### PR TITLE
Set OpenAI Library Version to 0.28.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
     install_requires=[
         'XBlock',
-        'openai',
+        'openai==0.28.0',
         'xblock-utils'
     ],
     entry_points={


### PR DESCRIPTION
This PR updates the OpenAI library version requirement in the `ai-coach-xblock` package to 0.28.0. Previously, the setup was installing the latest version of the OpenAI library, which was not compatible with our codebase. By specifying the version as `0.28.0`, we ensure compatibility and stability, as this version has been tested and confirmed to work well with our existing code. The `setup.py` file has been modified to reflect this specific version requirement in the `install_requires` section.