### PR TITLE
fix: AI Block availability in advanced modules

### DIFF
--- a/ai_coach/ai_coach.py
+++ b/ai_coach/ai_coach.py
@@ -75,10 +75,11 @@ class AICoachXBlock(XBlock, StudioEditableXBlockMixin, CompletableXBlockMixin):
 
     api_key = String(
         display_name=_("API Key"),
-        default=settings.OPENAI_SECRET_KEY,
+        default=getattr(settings, 'OPENAI_SECRET_KEY', ''),
         scope=Scope.settings,
         help=_(
-            "Your OpenAI API key, which can be found at <a href='https://platform.openai.com/account/api-keys' target='_blank'>https://platform.openai.com/account/api-keys</a>"
+            "Your OpenAI API key, which can be found at \
+            <a href='https://platform.openai.com/account/api-keys' target='_blank'>AI API Keys</a>"
         ),
     )
 
@@ -94,7 +95,8 @@ class AICoachXBlock(XBlock, StudioEditableXBlockMixin, CompletableXBlockMixin):
         values={'min': 0.1, 'max': 2, 'step': 0.1},
         scope=Scope.settings,
         help=_(
-            'Higher values like 0.8 will make the output more random, while lower values \n like 0.2 will make it more focused and deterministic.'
+            'Higher values like 0.8 will make the output more random, \
+            while lower values \n like 0.2 will make it more focused and deterministic.'
         )
     )
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description="AI Coach Xblock evaluates open response answer of a question using Open AI",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/edly-io/ai-feedback-xblock',
+    url='https://github.com/edly-io/ai-coach-xblock',
     license='AGPL v3',
     author='edly',
     packages=[


### PR DESCRIPTION
This PR fixes
1. AI Coach xblock was not available in Advanced component list. While trying to access it in shell it was throwing this error
```
>>> from ai_coach import ai_coach
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/ai-coach-xblock/ai_coach/__init__.py", line 1, in <module>
    from .ai_coach import AICoachXBlock
  File "/mnt/ai-coach-xblock/ai_coach/ai_coach.py", line 32, in <module>
    class AICoachXBlock(XBlock, StudioEditableXBlockMixin, CompletableXBlockMixin):
  File "/mnt/ai-coach-xblock/ai_coach/ai_coach.py", line 78, in AICoachXBlock
    default=settings.OPENAI_SECRET_KEY,
  File "/openedx/venv/lib/python3.8/site-packages/django/conf/__init__.py", line 104, in __getattr__
    val = getattr(_wrapped, name)
AttributeError: 'Settings' object has no attribute 'OPENAI_SECRET_KEY'
```
2. Long lines are split into multiple lines