### PR TITLE
fix: no module named importlib_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def package_data(pkg, roots):
 
 setup(
     name='ai-coach-xblock',
-    version='1.0.7',
+    version='1.0.8',
     description="AI Coach Xblock evaluates open response answer of a question using Open AI",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The AI Coach XBlock utilizes importlib_resources for file imports. This XBlock was developed during the Quince release, benefiting from the fact that the edx-platform included importlib_resources in both the Quince and Redwood versions. As a result, the XBlock functioned seamlessly across both releases.

However, with the recent removal of importlib_resources from the edx-platform, the XBlock now encounters errors related to Sumac. This pull request addresses and resolves the issue.

Additional context can be found [here](https://github.com/overhangio/openedx-scorm-xblock/pull/80#issue-2372890086).

