### PR TITLE
fix: bump openai version and alter prompt

### DIFF
--- a/ai_coach/ai_coach.py
+++ b/ai_coach/ai_coach.py
@@ -62,7 +62,7 @@ class AICoachXBlock(XBlock, StudioEditableXBlockMixin, CompletableXBlockMixin):
         Provide detailed feedback that includes:
         - An assessment of correctness.
         - Clear guidance on how to improve the answer, if needed.
-    """,
+        """,
         scope=Scope.settings,
         multiline_editor=True,
         help=_("Write the question context here"),

--- a/ai_coach/ai_coach.py
+++ b/ai_coach/ai_coach.py
@@ -198,8 +198,18 @@ class AICoachXBlock(XBlock, StudioEditableXBlockMixin, CompletableXBlockMixin):
         if self.feedback_count >= self.feedback_threshold:
             return {'error': _("You've exhausted all available chances to ask the coach for help")}
 
+        ai_context = self.context + """
+        Evaluate the student's response to the question below:
+        Question: {{question}}
+        Student's Answer: {{answer}}
+
+        Provide detailed feedback that includes:
+        - An assessment of correctness.
+        - Clear guidance on how to improve the answer, if needed.
+    """
+
         student_answer = data['answer'].strip()
-        prompt = self.context.replace('{{question}}', f'"{self.question}"')
+        prompt = ai_context.replace('{{question}}', f'"{self.question}"')
         prompt = prompt.replace('{{answer}}', f'"{student_answer}"')
 
         response = self.get_chat_completion(

--- a/ai_coach/ai_coach.py
+++ b/ai_coach/ai_coach.py
@@ -55,7 +55,14 @@ class AICoachXBlock(XBlock, StudioEditableXBlockMixin, CompletableXBlockMixin):
 
     context = String(
         display_name=_('Context'),
-        default="",
+        default="""
+        Evaluate my response to the question below:
+        Question: {{question}}
+        My Answer: {{answer}}
+        Provide detailed feedback that includes:
+        - An assessment of correctness.
+        - Clear guidance on how to improve the answer, if needed.
+    """,
         scope=Scope.settings,
         multiline_editor=True,
         help=_("Write the question context here"),

--- a/ai_coach/ai_coach.py
+++ b/ai_coach/ai_coach.py
@@ -199,9 +199,9 @@ class AICoachXBlock(XBlock, StudioEditableXBlockMixin, CompletableXBlockMixin):
             return {'error': _("You've exhausted all available chances to ask the coach for help")}
 
         ai_context = self.context + """
-        Evaluate the student's response to the question below:
+        Evaluate my response to the question below:
         Question: {{question}}
-        Student's Answer: {{answer}}
+        My Answer: {{answer}}
 
         Provide detailed feedback that includes:
         - An assessment of correctness.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ),
     install_requires=[
         'XBlock',
-        'openai==1.60.0'
+        'openai==1.65.1'
     ],
     entry_points={
         'xblock.v1': [

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ),
     install_requires=[
         'XBlock',
-        'openai==1.3.5'
+        'openai==1.60.0'
     ],
     entry_points={
         'xblock.v1': [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def package_data(pkg, roots):
 
 setup(
     name='ai-coach-xblock',
-    version='1.0.8',
+    version='1.0.9',
     description="AI Coach Xblock evaluates open response answer of a question using Open AI",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR covers two problems in the ai coach xblock. One of them is mentioned in the issue https://github.com/edly-io/ai-coach-xblock/issues/19. After debugging the issue, I found out that openai version 1.3.5 uses httpx version 0.25.2 under the hood where the Client class has an attribute named proxies which is no longer available in the latest httpx version (0.28). So, after bumping the version of openai, I was able to resolve this issue.
I identified the second problem while I was testing the xblock after bumping the openai version. The prompt was only considering the context set by the teacher and was not including the question and the student's response. So, the ai coach was not responding correctly. So, I included the question and student's answer in the prompt and also tested the ai coach after this addition.