### PR TITLE
fix: make xblock backwards compatible with quince and older releases

### DIFF
--- a/ai_coach/ai_coach.py
+++ b/ai_coach/ai_coach.py
@@ -1,4 +1,3 @@
-from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xblock.fields import Float, Integer, Scope, String
 from xblock.core import XBlock
 from xblock.completable import CompletableXBlockMixin
@@ -9,6 +8,11 @@ from django.conf import settings
 import logging
 
 from openai import OpenAI
+
+try:
+    from xblock.utils.studio_editable import StudioEditableXBlockMixin
+except ModuleNotFoundError: # For backward compatibility with releases older than Quince.
+    from xblockutils.studio_editable import StudioEditableXBlockMixin
 
 try:
     # Older Open edX releases (Redwood and earlier) install a backported version of

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def package_data(pkg, roots):
 
 setup(
     name='ai-coach-xblock',
-    version='1.0.9',
+    version='1.1.0',
     description="AI Coach Xblock evaluates open response answer of a question using Open AI",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -42,6 +42,7 @@ setup(
     ),
     install_requires=[
         'XBlock',
+        'xblock-utils',
         'openai==1.65.1'
     ],
     entry_points={


### PR DESCRIPTION
This issue was originally reported by @Anas-hameed. 

After the fix in #18, this xblock was not compatible with releases quince and older as they still use the `xblockutils` method.

We add a try catch to make sure it works in newer and older releases.